### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/workflow-ci.yml
+++ b/.github/workflows/workflow-ci.yml
@@ -3,6 +3,9 @@
 
 name: Workflow de Integração Continua
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/victor-dias21/all-books/security/code-scanning/1](https://github.com/victor-dias21/all-books/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the least privileges required for the workflow to function correctly. Since the workflow involves checking out the repository and running tests, the `contents: read` permission is sufficient. This permission allows the workflow to read repository contents without granting write access.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`testes`) to limit its scope. In this case, adding it at the root level is more concise and ensures consistency across all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
